### PR TITLE
Allow regular expressions as desktop notification highlight keywords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ tempNotes.*
 local_only_test.js
 sqlite3.js
 .unotes/
+*_log

--- a/VineExplorer.user.js
+++ b/VineExplorer.user.js
@@ -2399,9 +2399,8 @@ function updateNewProductsBtn() {
                     let _keyFound = false;
                     const _regExp = stringToRegex(_currKey);
                     if (_regExp !== undefined) {
-                        if (SETTINGS.DebugLevel > 1) console.log(`updateNewProductsBtn(): Search Product Description for Regular Expression: ${_currKey}`);
+                        if (SETTINGS.DebugLevel > 1) console.log(`updateNewProductsBtn(): Search Product Description for Regular Expression: ${_regExp}`);
                        _keyFound = _regExp.test(_descFull);
-                        if (SETTINGS.DebugLevel > 1) console.log(`updateNewProductsBtn(): Search Product Description for Regular Expression: ${_regExp}: ${_keyFound}`);
                     }
                     else {
                         if (SETTINGS.DebugLevel > 1) console.log(`updateNewProductsBtn(): Search Product Description for Keyword: ${_currKey}`);

--- a/VineExplorer.user.js
+++ b/VineExplorer.user.js
@@ -2380,10 +2380,12 @@ function updateNewProductsBtn() {
         let _notifyed = false;
         if (SETTINGS.EnableDesktopNotifikation && SETTINGS.DesktopNotifikationKeywords?.length > 0) {
 
-            if (SETTINGS.DebugLevel > 1) console.log(`updateNewProductsBtn(): Insige IF`);
+            if (SETTINGS.DebugLevel > 1) console.log(`updateNewProductsBtn(): Inside IF`);
 
             const _configKeyWords = SETTINGS.DesktopNotifikationKeywords;
 
+            // see https://stackoverflow.com/questions/874709/converting-user-input-string-to-regular-expression
+            var stringToRegex = (s, m) => (m = s.match(/^([\/~@;%#'])(.*?)\1([gimsuy]*)$/)) ? new RegExp(m[2], m[3].split('').filter((i, p, s) => s.indexOf(i) === p).join('')) : new RegExp(s);
 
             for (let i = 0; i < _prodArrLength; i++) {
                 const _prod = prodArr[i];
@@ -2394,12 +2396,28 @@ function updateNewProductsBtn() {
 
                 for (let j = 0; j < _configkeyWordsLength; j++) {
                     const _currKey = _configKeyWords[j].toLowerCase();
-                    if (SETTINGS.DebugLevel > 1) console.log(`updateNewProductsBtn(): Search Product Deescription for Keyword: ${_currKey}`);
-                    if (_descFull.includes(_currKey)) {
+                    let _keyFound = false;
+                    if (_currKey.startsWith('/')) {
+                        if (SETTINGS.DebugLevel > 1) console.log(`updateNewProductsBtn(): Search Product Description for Regular Expression: ${_currKey}`);
+
+                        try {
+                            const _regExp = stringToRegex(_currKey);
+                            _keyFound = _regExp.test(_descFull);
+                            if (SETTINGS.DebugLevel > 1) console.log(`updateNewProductsBtn(): Search Product Description for Regular Expression: ${_regExp}: ${_keyFound}`);
+                        } catch (error) {
+                            console.error('Error evaluating regular expression:', error);
+                            _keyFound = false;
+                        }
+                    }
+                    else {
+                        if (SETTINGS.DebugLevel > 1) console.log(`updateNewProductsBtn(): Search Product Description for Keyword: ${_currKey}`);
+                        _keyFound = _descFull.includes(_currKey);
+                    }
+                    if (_keyFound) {
                         desktopNotifikation(`Amazon Vine Explorer - ${AVE_VERSION}`, _prod.description_full, _prod.data_img_url, true);
                         _notifyed = true;
+                        break;
                     }
-                    break;
                 }
             }
         }

--- a/VineExplorer.user.js
+++ b/VineExplorer.user.js
@@ -2385,7 +2385,7 @@ function updateNewProductsBtn() {
             const _configKeyWords = SETTINGS.DesktopNotifikationKeywords;
 
             // see https://stackoverflow.com/questions/874709/converting-user-input-string-to-regular-expression
-            var stringToRegex = (s, m) => (m = s.match(/^([\/~@;%#'])(.*?)\1([gimsuy]*)$/)) ? new RegExp(m[2], m[3].split('').filter((i, p, s) => s.indexOf(i) === p).join('')) : new RegExp(s);
+            var stringToRegex = (s, m) => (m = s.match(/^\/(.*?)\/([gimsuy]*)$/)) ? new RegExp(m[1], m[2].split('').filter((i, p, s) => s.indexOf(i) === p).join('')) : undefined;
 
             for (let i = 0; i < _prodArrLength; i++) {
                 const _prod = prodArr[i];
@@ -2397,17 +2397,11 @@ function updateNewProductsBtn() {
                 for (let j = 0; j < _configkeyWordsLength; j++) {
                     const _currKey = _configKeyWords[j].toLowerCase();
                     let _keyFound = false;
-                    if (_currKey.startsWith('/')) {
+                    const _regExp = stringToRegex(_currKey);
+                    if (_regExp !== undefined) {
                         if (SETTINGS.DebugLevel > 1) console.log(`updateNewProductsBtn(): Search Product Description for Regular Expression: ${_currKey}`);
-
-                        try {
-                            const _regExp = stringToRegex(_currKey);
-                            _keyFound = _regExp.test(_descFull);
-                            if (SETTINGS.DebugLevel > 1) console.log(`updateNewProductsBtn(): Search Product Description for Regular Expression: ${_regExp}: ${_keyFound}`);
-                        } catch (error) {
-                            console.error('Error evaluating regular expression:', error);
-                            _keyFound = false;
-                        }
+                       _keyFound = _regExp.test(_descFull);
+                        if (SETTINGS.DebugLevel > 1) console.log(`updateNewProductsBtn(): Search Product Description for Regular Expression: ${_regExp}: ${_keyFound}`);
                     }
                     else {
                         if (SETTINGS.DebugLevel > 1) console.log(`updateNewProductsBtn(): Search Product Description for Keyword: ${_currKey}`);

--- a/VineExplorer.user.js
+++ b/VineExplorer.user.js
@@ -2391,7 +2391,12 @@ function updateNewProductsBtn() {
                 const _prod = prodArr[i];
                 const _descFull = _prod.description_full.toLowerCase();
 
-                if (SETTINGS.DebugLevel > 1) console.log(`updateNewProductsBtn(): Search Product Deescription: ${_descFull} for keys: `, _configKeyWords);
+                if (_prod.isNotified){
+                    if (SETTINGS.DebugLevel > 1) console.log(`updateNewProductsBtn(): Skipping Product which was already notified: ${_descFull}`);
+                    continue;
+                }
+
+                if (SETTINGS.DebugLevel > 1) console.log(`updateNewProductsBtn(): Search Product Description: ${_descFull} for keys: `, _configKeyWords);
                 const _configkeyWordsLength = _configKeyWords.length;
 
                 for (let j = 0; j < _configkeyWordsLength; j++) {
@@ -2409,6 +2414,8 @@ function updateNewProductsBtn() {
                     if (_keyFound) {
                         desktopNotifikation(`Amazon Vine Explorer - ${AVE_VERSION}`, _prod.description_full, _prod.data_img_url, true);
                         _notifyed = true;
+                        _prod.isNotified = true;
+                        database.update(_prod);
                         break;
                     }
                 }

--- a/class_product.js
+++ b/class_product.js
@@ -21,6 +21,7 @@ class Product {
     real_prize;
     isFav = false;
     isNew = true;
+    isNotified = false;
     gotRemoved = false;
     ts_firstSeen = unixTimeStamp();
     ts_lastSeen = unixTimeStamp();


### PR DESCRIPTION
When a desktop notification highlight keyword has the form _"/<regular expression>/<regular expression options>"_ (without the quotes), it is treated as a regular expression while searching for matching products